### PR TITLE
Bumping deployment target due to Xcode 12 warning

### DIFF
--- a/StringTemplate.podspec
+++ b/StringTemplate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'StringTemplate'
-  spec.version = '1.0.2'
+  spec.version = '1.0.3'
   spec.license = 'Apache License, Version 2.0'
   spec.homepage = 'https://github.com/square/StringTemplate'
   spec.authors = 'Square'
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
   spec.requires_arc = true
   spec.compiler_flags = '-whole-module-optimization'
-  spec.ios.deployment_target = '8.0'
+  spec.ios.deployment_target = '9.0'
   spec.osx.deployment_target = '10.9'
   spec.watchos.deployment_target = '2.0'
   spec.tvos.deployment_target = '9.0'


### PR DESCRIPTION
Building StringTemplate on Xcode 12 gives the warning `The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99.`

Updating the `deployment_target` in the podspec will remove this issue, but will also drop support for iOS 8 devices.