### PR TITLE
Bump minimum target to 9.0

### DIFF
--- a/StringTemplate.podspec
+++ b/StringTemplate.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
   spec.requires_arc = true
   spec.compiler_flags = '-whole-module-optimization'
-  spec.ios.deployment_target = '8.0'
+  spec.ios.deployment_target = '9.0'
   spec.osx.deployment_target = '10.9'
   spec.watchos.deployment_target = '2.0'
   spec.tvos.deployment_target = '9.0'


### PR DESCRIPTION
Xcode 12+ doesn't support building for 8.0, and this is causing some issues with command line tooling. Can we bump this to 9.0?