### PR TITLE
Mark spec as explicitly extension safe

### DIFF
--- a/StringTemplate.podspec
+++ b/StringTemplate.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |spec|
   spec.tvos.deployment_target = '9.0'
 
   spec.pod_target_xcconfig = {
-    'APPLICATION_EXTENSION_API_ONLY' => 'NO',
+    'APPLICATION_EXTENSION_API_ONLY' => 'YES',
   }
 end

--- a/StringTemplate.podspec
+++ b/StringTemplate.podspec
@@ -15,4 +15,8 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target = '10.9'
   spec.watchos.deployment_target = '2.0'
   spec.tvos.deployment_target = '9.0'
+
+  spec.pod_target_xcconfig = {
+    'APPLICATION_EXTENSION_API_ONLY' => 'NO',
+  }
 end


### PR DESCRIPTION
This is _often_ implicit when used as a dependency; however, it is easier to enforce this here in order make builds fail.

I've been doing this with a bunch of Square dependencies so that I can enforce it in some private square libraries.

https://github.com/square/Listable/pull/441
https://github.com/square/Blueprint/pull/409